### PR TITLE
license: fix year and authors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
-
 The MIT License (MIT)
 
-Copyright (c) 2018 GitHub, Inc. and contributors
+Copyright (c) 2020 Tarantool AUTHORS and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Just fix the result of an inattentive copy-paste.